### PR TITLE
Handling some edge cases

### DIFF
--- a/src/erlcscope.erl
+++ b/src/erlcscope.erl
@@ -29,11 +29,12 @@ main(InPath)->
 	{ok, Db} = file:open(?OUTPUT_FILE,[write]),
 	init_symbol_db(Db,0),
 	Sched = erlang:system_info(schedulers),
+	Limit = erlang:min(Sched, length(Files)),
 	Entries = pmap_lim(fun(Fname) ->
 			S = build_symbol_db_from_file(Fname),
 			list_to_binary(lists:reverse(S#state.entries))
 		end,
-	Files, Sched),
+	Files, Limit),
 	lists:foreach(fun(E) -> file:write(Db, E) end, Entries),
 	write_symbol_trailer_to_db(Db, Files),
 	io:format("Processed ~b files~n", [length(Files)])

--- a/src/erlcscope.erl
+++ b/src/erlcscope.erl
@@ -299,7 +299,10 @@ get_define_name(Def) ->
 		application ->
 			get_define_name(erl_syntax:application_operator(Def));
 		atom ->
-			erl_syntax:atom_literal(Def)
+			erl_syntax:atom_literal(Def);
+		underscore ->
+			erl_syntax:underscore()
+
 	end.
 
 % recursively find erlang files, returns a list of filenames

--- a/src/erlcscope.erl
+++ b/src/erlcscope.erl
@@ -32,7 +32,7 @@ main(InPath)->
 	Entries = pmap_lim(fun(Fname) ->
 			S = build_symbol_db_from_file(Fname),
 			list_to_binary(lists:reverse(S#state.entries))
-		end, 
+		end,
 	Files, Sched),
 	lists:foreach(fun(E) -> file:write(Db, E) end, Entries),
 	write_symbol_trailer_to_db(Db, Files),
@@ -143,10 +143,10 @@ process_attribute(Node,S=#state{}) ->
 			process_define(Node,S);
 		record ->
 			process_record(Node,S);
-		_ -> 
+		_ ->
 			{[],S}
 	end.
- 	
+
 process_define(Node,S=#state{}) ->
 	%io:format("subtree ~p~n",[erl_syntax:attribute_arguments(Node)]),
 	[Def | Subtree] = erl_syntax:attribute_arguments(Node),
@@ -175,10 +175,10 @@ process_function(Node, S=#state{}) ->
 
 process_record(Node, S=#state{}) ->
 	try erl_syntax_lib:analyze_record_attribute(Node) of
-		{RecName, _Fields}  -> 
+		{RecName, _Fields}  ->
 			NewState1 = write_symbol_to_db(?RECORD_DEF_MARK, atom_to_list(RecName), Node, S),
 			{[] , write_symbol_to_db(?RECORD_DEF_END_MARK, "", Node, NewState1) }
-	catch 
+	catch
 		syntax_error ->
 			{[],S}
 	end.
@@ -233,9 +233,9 @@ write_symbol_to_db(Type, Name, Node, S=#state{entries = Entries}) when length(Na
 	end,
 	FoundLen = string:str( string:sub_string(Line, SearchPos), Name),
 	%io:format("fount ~p at ~p~n",[Name,FoundLen]),
-	case FoundLen > 0 of 
+	case FoundLen > 0 of
 	   true ->
-		{StartPos, L1} = 
+		{StartPos, L1} =
 		 if (LineNo =/= S#state.line_no) ->
 	 			% we have moved to new line, complete the old line
 		     	% and write the new line number
@@ -262,7 +262,7 @@ write_symbol_to_db(Type, Name, Node, S=#state{entries = Entries}) when length(Na
 
 % XXX: This assumes that there won't be two functions in the same line ...
 % called for CLOSE of FUNCTION/MACRO
- 
+
 write_symbol_to_db(Type, "", _Node, S=#state{entries = Entries}) ->
 	% write the left over bytes
 	Line = binary_to_list(array:get(S#state.line_no-1, S#state.data)),
@@ -270,7 +270,7 @@ write_symbol_to_db(Type, "", _Node, S=#state{entries = Entries}) ->
 	%NewLine = S#state.line_no+1,
 	%S#state{line_no=NewLine,pos=1};
 	S#state{entries = [L | Entries]};
-	
+
 write_symbol_to_db(_Type, _Name, _Node, S=#state{}) ->
 	S.
 

--- a/tests/cscope.files
+++ b/tests/cscope.files
@@ -1,1 +1,2 @@
 ./test.erl
+./special.erl

--- a/tests/special.erl
+++ b/tests/special.erl
@@ -1,0 +1,22 @@
+%% Some special cases to check for bugs in erlcscope
+%%
+-module(special_record).
+
+%% This exhibited a crash in erlscope:write_symbol_to_db/4. The crash:
+%%
+%% =ERROR REPORT==== 13-Jan-2017::23:26:39 ===
+%% Error in process <0.1167.0> with exit value:
+%% {badarg,[{array,get,2,[{file,"array.erl"},{line,650}]},
+%%          {erlcscope,write_symbol_to_db,4,
+%%                     [{file,"src/erlcscope.erl"},{line,268}]},
+%%          {erlcscope,process_record,2,[{file,"src/erlcscope.erl"},{line,179}]},
+%%          {erlcscope,'-traverse_tree/2-fun-0-',2,
+%%                     [{file,"src/erlcscope.erl"},{line,95}]},
+%%          {lists,foldl,3,[{file,"lists.erl"},{line,1263}]},
+%%          {erlcscope,'-main/1-fun-1-',1,[{file,"src/erlcscope.erl"},{line,33}]},
+%%          {erlcscope,pmap_lim_run,3,[{file,"src/erlcscope.erl"},{line,67}]}]}
+-record('', {}).
+
+%% This is allowed as well and should not lead to a crash.
+''() ->
+	 ok.


### PR DESCRIPTION
While running `erlcscope` against a large Erlang code base, I encountered an unhandled edge cases in what erlang allows as atoms: an Erlang record can be named `''`, as can a function. While pursuing this, I fixed some smaller problems on the way. Note that I included a commit to drop whitespace. If you'd prefer the changeset without this commit, I can remove it.

I added a simple work-around to make debugging easier by outputting the name of the Erlang source file if it triggered a crash in `erlcscope`.